### PR TITLE
Persist Etymology Documentation

### DIFF
--- a/src/Etymology.Web/wwwroot/index.htm
+++ b/src/Etymology.Web/wwwroot/index.htm
@@ -260,17 +260,17 @@
                             <p><b>Usage example 用法举例:</b> 車子 chē zǐ (car)</p>
                             <p><b>Importance by frequency 常用频率:</b> 369</p>
                             <p><b>Shuowen 说文解字:</b> 輿輪之緫名夏后時奚仲所造象形凡車之屬皆從車</p>
-                            <p class="pre-inline"><b>Character decomposition 字形分解 <a href="https://dixin.github.io/Etymology/decomposition-of-chinese-character" target="_blank" title="Help: Decomposition of Chinese character">[?]</a>:</b> <br>Component 車
+                            <p class="pre-inline"><b>Character decomposition 字形分解 <a href="https://github.com/Dixin/Etymology/blob/main/docs/_posts/2018-04-23-decomposition-of-chinese-character.md" target="_blank" title="Help: Decomposition of Chinese character">[?]</a>:</b> <br>Component 車
                                 new-char 车
                                 (name- cart-che 车車 chē)</p>
-                            <p class="pre-inline"><b>Decomposition notes 字形分解说明 <a href="https://dixin.github.io/Etymology/decomposition-of-chinese-character" target="_blank" title="Help: Decomposition of Chinese character">[?]</a>:</b> <br>(- two wheeled cart)</p>
-                            <p><b>Simplification rule 简化规则 <a href="https://dixin.github.io/Etymology/simplification-of-chinese-character" target="_blank" title="Help: Simplification of Chinese character">[?]</a>:</b> B014 车[車]</p>
-                            <p class="pre-inline"><b>Simplification rule explained 简化规则说明 <a href="https://dixin.github.io/Etymology/simplification-of-chinese-character" target="_blank" title="Help: Simplification of Chinese character">[?]</a>:</b> <br>new character
+                            <p class="pre-inline"><b>Decomposition notes 字形分解说明 <a href="https://github.com/Dixin/Etymology/blob/main/docs/_posts/2018-04-23-decomposition-of-chinese-character.md" target="_blank" title="Help: Decomposition of Chinese character">[?]</a>:</b> <br>(- two wheeled cart)</p>
+                            <p><b>Simplification rule 简化规则 <a href="https://github.com/Dixin/Etymology/blob/main/docs/_posts/2018-04-23-simplification-of-chinese-character.md" target="_blank" title="Help: Simplification of Chinese character">[?]</a>:</b> B014 车[車]</p>
+                            <p class="pre-inline"><b>Simplification rule explained 简化规则说明 <a href="https://github.com/Dixin/Etymology/blob/main/docs/_posts/2018-04-23-simplification-of-chinese-character.md" target="_blank" title="Help: Simplification of Chinese character">[?]</a>:</b> <br>new character
                                 cursive simplification 车車</p>
-                            <p><b>Variant rule 异体规则 <a href="https://dixin.github.io/Etymology/simplification-of-chinese-character" target="_blank">[?]</a>:</b> C999</p>
-                            <p class="pre-inline"><b>Variant rule clarification 异体规则说明 <a href="https://dixin.github.io/Etymology/simplification-of-chinese-character" target="_blank" title="Help: Simplification of Chinese character">[?]</a>:</b> <br>Not applicable.</p>
-                            <p><b>Applied rules 应用规则 <a href="https://dixin.github.io/Etymology/simplification-of-chinese-character" target="_blank" title="Help: Simplification of Chinese character">[?]</a>:</b> Not applicable.</p>
-                            <p><b>New font rule 新字形规则 <a href="https://dixin.github.io/Etymology/simplification-of-chinese-character" target="_blank" title="Help: Simplification of Chinese character">[?]</a>:</b> Not applicable.</p>
+                            <p><b>Variant rule 异体规则 <a href="https://github.com/Dixin/Etymology/blob/main/docs/_posts/2018-04-23-simplification-of-chinese-character.md" target="_blank">[?]</a>:</b> C999</p>
+                            <p class="pre-inline"><b>Variant rule clarification 异体规则说明 <a href="https://github.com/Dixin/Etymology/blob/main/docs/_posts/2018-04-23-simplification-of-chinese-character.md" target="_blank" title="Help: Simplification of Chinese character">[?]</a>:</b> <br>Not applicable.</p>
+                            <p><b>Applied rules 应用规则 <a href="https://github.com/Dixin/Etymology/blob/main/docs/_posts/2018-04-23-simplification-of-chinese-character.md" target="_blank" title="Help: Simplification of Chinese character">[?]</a>:</b> Not applicable.</p>
+                            <p><b>New font rule 新字形规则 <a href="https://github.com/Dixin/Etymology/blob/main/docs/_posts/2018-04-23-simplification-of-chinese-character.md" target="_blank" title="Help: Simplification of Chinese character">[?]</a>:</b> Not applicable.</p>
 
                             <a class="btn btn-warning btn-xs ladda-button" data-style="zoom-in" href="https://github.com/Dixin/Etymology/issues/new" target="_blank" title="Help: Simplification of Chinese character"><span class="glyphicon glyphicon-share-alt" aria-hidden="true"></span> Report issue 报错/留言</a>
                         </div>
@@ -650,12 +650,12 @@
                         <h2 class="panel-title" style="font-size: 30px; margin-top: 10px; margin-bottom: 10px;"><span class="glyphicon glyphicon-search" aria-hidden="true"></span> Chinese character and etymology research 汉字和字源研究</h2>
                     </div>
                     <div class="list-group etymology-research">
-                        <a target="_blank" href="https://dixin.github.io/Etymology/why-study-chinese-etymology" class="list-group-item">Why study Chinese Etymology 中国文字的历史</a>
-                        <a target="_blank" href="https://dixin.github.io/Etymology/spoken-chinese-and-other-languages" class="list-group-item">Spoken Chinese and Other Languages</a>
-                        <a target="_blank" href="https://dixin.github.io/Etymology/what-is-a-simplified-chinese-character" class="list-group-item">What is a Simplified Chinese Character</a>
-                        <a target="_blank" href="https://dixin.github.io/Etymology/what-is-a-traditional-chinese-character" class="list-group-item">What is a Traditional Chinese Character</a>
-                        <a target="_blank" href="https://dixin.github.io/Etymology/decomposition-of-chinese-character" class="list-group-item">Decomposition of Chinese Character</a>
-                        <a target="_blank" href="https://dixin.github.io/Etymology/simplification-of-chinese-character" class="list-group-item">Simplification of Chinese Character</a>
+                        <a target="_blank" href="https://github.com/Dixin/Etymology/blob/main/docs/_posts/2017-09-17-why-study-chinese-etymology.md" class="list-group-item">Why study Chinese Etymology 中国文字的历史</a>
+                        <a target="_blank" href="https://github.com/Dixin/Etymology/blob/main/docs/_posts/2017-09-18-spoken-chinese-and-other-languages.md" class="list-group-item">Spoken Chinese and Other Languages</a>
+                        <a target="_blank" href="https://github.com/Dixin/Etymology/blob/main/docs/_posts/2017-09-19-what-is-a-simplified-chinese-character.md" class="list-group-item">What is a Simplified Chinese Character</a>
+                        <a target="_blank" href="https://github.com/Dixin/Etymology/blob/main/docs/_posts/2017-09-19-what-is-a-traditional-chinese-character.md" class="list-group-item">What is a Traditional Chinese Character</a>
+                        <a target="_blank" href="https://github.com/Dixin/Etymology/blob/main/docs/_posts/2018-04-23-decomposition-of-chinese-character.md" class="list-group-item">Decomposition of Chinese Character</a>
+                        <a target="_blank" href="https://github.com/Dixin/Etymology/blob/main/docs/_posts/2018-04-23-simplification-of-chinese-character.md" class="list-group-item">Simplification of Chinese Character</a>
                         <p class="list-group-item">(More articles are coming.)</p>
                     </div>
                 </div>


### PR DESCRIPTION
resolves #158, resolves #170, resolves #171, resolves #175, and resolves #177.

as mentioned by several users, the hyperlinks to etymology documentation, which help explain various paradigms of the system, link to pages that no longer exist from an old database/repository. but these resources appear to still exist within this new repo, so this pull request reroutes the existing hyperlinks to those resources within this repository.